### PR TITLE
Add Vite frontend config

### DIFF
--- a/secunik/frontend/package.json
+++ b/secunik/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "secunik-frontend",
+  "version": "1.0.0",
+  "description": "SecuNik Frontend - Ultimate Cybersecurity Analysis Platform",
+  "private": true,
+  "scripts": {
+    "dev": "vite --host",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "date-fns": "^2.30.0",
+    "pinia": "^2.1.7",
+    "uuid": "^9.0.1",
+    "vue": "^3.3.8",
+    "vue-router": "^4.2.5"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.4",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.3.6",
+    "vite": "^6.3.5"
+  }
+}

--- a/secunik/frontend/vite.config.js
+++ b/secunik/frontend/vite.config.js
@@ -1,0 +1,7 @@
+// vite.config.js
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()]
+})


### PR DESCRIPTION
## Summary
- create `package.json` with Vue/Vite dependencies
- set up Vite in `vite.config.js`

## Testing
- `npm install`
- `npm run dev` *(fails: MODULE_TYPELESS_PACKAGE_JSON warning but server started)*

------
https://chatgpt.com/codex/tasks/task_e_684fde9baabc83239b309eeca28c521f