### PR TITLE
Fix dashboard model imports

### DIFF
--- a/secunik/backend/app/models/dashboard.py
+++ b/secunik/backend/app/models/dashboard.py
@@ -2,6 +2,10 @@
 Dashboard data models
 """
 
+from typing import Optional, List, Dict, Any
+from datetime import datetime
+from pydantic import BaseModel, Field
+
 class DashboardStats(BaseModel):
     """Dashboard statistics"""
     total_cases: int = 0


### PR DESCRIPTION
## Summary
- add missing imports for dashboard models

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*
- `pip install -r secunik/requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_6851292434808323a435f2a5ba74b45c